### PR TITLE
Updates to library API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,14 +49,28 @@ set(TS_LIB_HEADERS
     include/ts_common.h
     )
 
+####
+# LIBTSLITEX SHARED LIBRARY
+####
 add_library(tslitex SHARED ${TS_SOURCES}
             ${TS_LIB_HEADERS}
             )
 
-set_target_properties(tslitex PROPERTIES POSITION_INDEPENDENT_CODE 1)
-
-
 target_link_libraries(tslitex litepcie)
 target_include_directories(tslitex PUBLIC include)
+
+####
+# LIBTSLITEX STATIC LIBRARY
+####    
+add_library(tslitex_static STATIC ${TS_SOURCES}
+            ${TS_LIB_HEADERS}
+            )
+
+#target_compile_definitions(tslitex_static tslitex_static_STATIC)
+set_target_properties(tslitex_static PROPERTIES POSITION_INDEPENDENT_CODE 1)
+
+
+target_link_libraries(tslitex_static litepcie)
+target_include_directories(tslitex_static PUBLIC include)
 
 file(COPY ${TS_LIB_HEADERS} DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ add_subdirectory(litepcie)
 
 add_subdirectory(example)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 set(TS_SOURCES
     src/i2c.c
     src/gpio.c
@@ -47,7 +49,7 @@ set(TS_LIB_HEADERS
     include/ts_common.h
     )
 
-add_library(tslitex STATIC ${TS_SOURCES}
+add_library(tslitex SHARED ${TS_SOURCES}
             ${TS_LIB_HEADERS}
             )
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,8 +2,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/artifacts/example")
 
 add_executable(thunderscope_test thunderscope_test.cpp)
 
-target_link_libraries(thunderscope_test litepcie)
-target_link_libraries(thunderscope_test tslitex)
+target_link_libraries(thunderscope_test tslitex_static)
 
 if(WIN32)
     target_link_libraries(thunderscope_test setupapi)

--- a/include/thunderscope.h
+++ b/include/thunderscope.h
@@ -7,6 +7,7 @@
  * Copyright (C) 2024 / Nate Meyer  / nate.devel@gmail.com
  *
  */
+
 #ifndef _THUNDERSCOPE_H_
 #define _THUNDERSCOPE_H_
 
@@ -15,12 +16,74 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "ts_common.h"
 
-int32_t thunderscopeInit(void);
-int32_t thunderscopeListDevices(void);
-int32_t thunderscopeOpen(void);
+/**
+ * @brief Get the name of a device from a list of available devices
+ * 
+ * @param devIndex Index to search
+ * @param nameBuffer Pointer to the string buffer to return the device name
+ * @param bufLen Length of the available space in the name buffer
+ * @return int32_t TS_STATUS_OK if the name is valid, else TS_STATUS_ERROR
+ */
+int32_t thunderscopeListDevices(uint32_t devIndex, char* nameBuffer, uint32_t bufLen);
+
+/**
+ * @brief Open a new Thunderscope device instance
+ * 
+ * @param devName Path to the device
+ * @return tsHandle_t Handle to the Thunderscope device
+ */
+tsHandle_t thunderscopeOpen(char* devName);
+
+/**
+ * @brief Close the Thunderscope device
+ * 
+ * @param ts Handle to the Thunderscope device
+ * @return int32_t TS_STATUS_OK if the device was closed
+ */
+int32_t thunderscopeClose(tsHandle_t ts);
+
+/**
+ * @brief Get the current configuration of a channel on the Thunderscope device
+ * 
+ * @param ts Handle to the Thunderscope device
+ * @param channel Channel number
+ * @param conf Reference used to return the Channel configuration
+ * @return int32_t 
+ */
+int32_t thunderscopeChannelConfigGet(tsHandle_t ts, uint32_t channel, tsChannelParam_t* conf);
+
+/**
+ * @brief Set the configuration for a channel on the Thunderscope device
+ * 
+ * @param ts Handle to the Thunderscope device
+ * @param channel Channel number
+ * @param conf Channel configuration structure
+ * @return int32_t TS_STATUS_OK if the channel was configured
+ */
+int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelParam_t conf);
+
+/**
+ * @brief Enable or Disable 
+ * 
+ * @param ts Handle to the Thunderscope device
+ * @param enable Flag to enable or disable the ADC data
+ * @return int32_t TS_STATUS_OK if the command was applied correctly
+ */
+int32_t thunderscopeDataEnable(tsHandle_t ts, bool enable);
+
+/**
+ * @brief Read data into a buffer
+ * 
+ * @param ts Handle to the Thunderscope device
+ * @param buffer Pointer to a buffer to store data samples in
+ * @param len Length of the data buffer available
+ * @return int32_t Length of the data read into the buffer, or a negative error code
+ */
+int32_t thunderscopeRead(tsHandle_t ts, uint8_t* buffer, uint32_t len);
 
 #ifdef __cplusplus
 }

--- a/include/thunderscope.h
+++ b/include/thunderscope.h
@@ -61,10 +61,10 @@ int32_t thunderscopeChannelConfigGet(tsHandle_t ts, uint32_t channel, tsChannelP
  * 
  * @param ts Handle to the Thunderscope device
  * @param channel Channel number
- * @param conf Channel configuration structure
+ * @param conf Reference to the Channel configuration structure
  * @return int32_t TS_STATUS_OK if the channel was configured
  */
-int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelParam_t conf);
+int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelParam_t* conf);
 
 /**
  * @brief Enable or Disable 

--- a/include/thunderscope.h
+++ b/include/thunderscope.h
@@ -73,7 +73,7 @@ int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelP
  * @param enable Flag to enable or disable the ADC data
  * @return int32_t TS_STATUS_OK if the command was applied correctly
  */
-int32_t thunderscopeDataEnable(tsHandle_t ts, bool enable);
+int32_t thunderscopeDataEnable(tsHandle_t ts, uint8_t enable);
 
 /**
  * @brief Read data into a buffer

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -37,11 +37,11 @@ typedef enum tsChannelCoupling_e
 
 typedef struct tsChannelParam_s
 {
-    bool active;
+    uint8_t active;
     uint32_t volt_scale;
     uint32_t bandwidth;
     tsChannelCoupling_t coupling;
-    bool attenuation;
+    uint8_t attenuation;
 } tsChannelParam_t;
 
 typedef struct tsChannelConfig_s

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -35,13 +35,19 @@ typedef enum tsChannelCoupling_e
     TS_COUPLE_AC = 1
 } tsChannelCoupling_t;
 
+typedef enum tsChannelTerm_e {
+    TS_TERM_1M = 0,
+    TS_TERM_50 = 1,
+} tsChannelTerm_t;
+
 typedef struct tsChannelParam_s
 {
-    uint8_t active;
-    uint32_t volt_scale;
-    uint32_t bandwidth;
-    tsChannelCoupling_t coupling;
-    uint8_t attenuation;
+    uint32_t volt_scale_mV;     /**< Set full scale voltage in millivolts */
+    uint32_t volt_offset_mV;    /**< Set offset voltage in millivolts */
+    uint32_t bandwidth;         /**< Set Bandwidth Filter in MHz. Next highest filter will be selected */
+    uint8_t coupling;           /**< Select AD/DC coupling for channel.  Use tsChannelCoupling_t enum */
+    uint8_t term;               /**< Select Termination mode for channel.  Use tsChannelTerm_t enum */
+    uint8_t active;             /**< Active flag for the channel. 1 to enable, 0 to disable */
 } tsChannelParam_t;
 
 typedef struct tsChannelConfig_s

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -14,17 +14,41 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define TS_STATUS_OK                (0)
 #define TS_STATUS_ERROR             (-1)
 
 
-#if defined(_WIN32)
-#include <windows.h>
-typedef HANDLE tsHandle_t;
-#else
-typedef int32_t tsHandle_t;
-#endif
+#define TS_NUM_CHANNELS             (4)
+
+/**
+ * @brief Opaque Handle to a Thunderscope device instance
+ *  
+ */
+typedef void* tsHandle_t;
+
+
+typedef enum tsChannelCoupling_e
+{
+    TS_COUPLE_DC = 0,
+    TS_COUPLE_AC = 1
+} tsChannelCoupling_t;
+
+typedef struct tsChannelParam_s
+{
+    bool active;
+    uint32_t volt_scale;
+    uint32_t bandwidth;
+    tsChannelCoupling_t coupling;
+    bool attenuation;
+} tsChannelParam_t;
+
+typedef struct tsChannelConfig_s
+{
+    tsChannelParam_t channels[TS_NUM_CHANNELS];
+    uint32_t adc_sample_rate;
+} tsChannelConfig_t;
 
 #ifdef __cplusplus
 }

--- a/src/platform.h
+++ b/src/platform.h
@@ -11,7 +11,6 @@
 #include "ts_common.h"
 #include "csr.h"
 
-#define TS_NUM_CHANNELS         (4)
 
 #define TS_SPI_BUS_BASE_ADDR    CSR_MAIN_SPI_BASE    
 #define TS_SPI_BUS_CS_NUM       (CSR_MAIN_SPI_CS_SEL_SIZE)

--- a/src/thunderscope.c
+++ b/src/thunderscope.c
@@ -7,19 +7,87 @@
  * Copyright (C) 2024 / Nate Meyer  / nate.devel@gmail.com
  *
  */
+#include <stdlib.h>
+
 #include "thunderscope.h"
+#include "ts_common.h"
+
 #include "i2c.h"
 #include "spi.h"
 #include "litepcie.h"
 
-
-
-int32_t thunderscopeInit(void)
+typedef struct ts_inst_s
 {
+    file_t ctrl;
+    struct litepcie_dma_ctrl dma;
+    tsChannelConfig_t conf;
+    //TBD - Other Instance Data
+} ts_inst_t;
+
+
+int32_t thunderscopeListDevices(uint32_t devIndex, char* nameBuffer, uint32_t bufLen)
+{
+    int32_t retVal = TS_STATUS_ERROR;
+    
+    // Find device path by index
+
+    //If index valid
+    if(devIndex)
+    {
+        retVal = TS_STATUS_OK;
+    }
+
+    return retVal;
+}
+
+tsHandle_t thunderscopeOpen(char* name)
+{
+    tsHandle_t ts = NULL;
+    
+    if(!name)
+    {
+        return ts;
+    } 
+
+    return ts;
+}
+
+
+int32_t thunderscopeClose(tsHandle_t ts)
+{
+    if(ts == NULL)
+    {
+        return TS_STATUS_ERROR;
+    }
+
+    ts_inst_t* pInst = (ts_inst_t*)ts;
+    
+    litepcie_dma_cleanup(&pInst->dma);
+    litepcie_close(pInst->ctrl);
+
     return TS_STATUS_OK;
 }
 
-int32_t thunderscopeOpen(void)
+int32_t thunderscopeChannelConfigGet(tsHandle_t ts, uint32_t channel, tsChannelParam_t* conf)
 {
-    return TS_STATUS_OK;
+    //TODO
+    return TS_STATUS_ERROR;
+}
+
+int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelParam_t conf)
+{
+    //TODO
+    return TS_STATUS_ERROR;
+}
+
+int32_t thunderscopeDataEnable(tsHandle_t ts, bool enable)
+{
+    //TODO
+    return TS_STATUS_ERROR;
+}
+
+int32_t thunderscopeRead(tsHandle_t ts, uint8_t* buffer, uint32_t len)
+{
+    //TODO
+    return TS_STATUS_ERROR;
 }

--- a/src/thunderscope.c
+++ b/src/thunderscope.c
@@ -80,7 +80,7 @@ int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelP
     return TS_STATUS_ERROR;
 }
 
-int32_t thunderscopeDataEnable(tsHandle_t ts, bool enable)
+int32_t thunderscopeDataEnable(tsHandle_t ts, uint8_t enable)
 {
     //TODO
     return TS_STATUS_ERROR;

--- a/src/thunderscope.c
+++ b/src/thunderscope.c
@@ -74,7 +74,7 @@ int32_t thunderscopeChannelConfigGet(tsHandle_t ts, uint32_t channel, tsChannelP
     return TS_STATUS_ERROR;
 }
 
-int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelParam_t conf)
+int32_t thunderscopeChannelConfigSet(tsHandle_t ts, uint32_t channel, tsChannelParam_t* conf)
 {
     //TODO
     return TS_STATUS_ERROR;


### PR DESCRIPTION
This PR fills in some of the top-level API for libtslitex, specifically the thunderscope.h function prototypes and channel parameters structure.

Also, add builds for both static and shared libraries in cmake.