### PR TITLE
Calibration API

### DIFF
--- a/include/thunderscope.h
+++ b/include/thunderscope.h
@@ -84,16 +84,6 @@ int32_t thunderscopeStatusGet(tsHandle_t ts, tsScopeState_t* conf);
 int32_t thunderscopeSampleModeSet(tsHandle_t ts, uint32_t rate, uint32_t resolution);
 
 /**
- * @brief Set the calibration data for a channel on the Thunderscope device
- * 
- * @param ts Handle to the Thunderscope device
- * @param channel Channel number
- * @param cal TBD Calibration data
- * @return int32_t TS_STATUS_OK if the calibration was accepted
-*/
-int32_t thunderscopeCalibrationSet(tsHandle_t ts, uint32_t channel, uint32_t cal);
-
-/**
  * @brief Enable or Disable 
  * 
  * @param ts Handle to the Thunderscope device

--- a/include/ts_calibration.h
+++ b/include/ts_calibration.h
@@ -31,6 +31,7 @@ typedef struct tsChannelCalibration_s
     int32_t preampOutputGainError_mdB;
     int32_t preampLowOffset_mV;
     int32_t preampHighOffset_mV;
+    int32_t preampInputBias_uA;
 } tsChannelCalibration_t;
 
 

--- a/include/ts_calibration.h
+++ b/include/ts_calibration.h
@@ -34,6 +34,23 @@ typedef struct tsChannelCalibration_s
     int32_t preampInputBias_uA;
 } tsChannelCalibration_t;
 
+typedef struct tsChannelCtrl_e
+{
+    // FE Attenuator
+    uint8_t atten;
+    // FE Termination
+    uint8_t term;
+    // DC Coupling
+    uint8_t dc_couple;
+    // Trim DAC
+    uint16_t dac;
+    // Trim DPOT
+    uint8_t dpot;
+    //Preamp Control
+    uint8_t pga_high_gain;
+    uint8_t pga_atten;
+    uint8_t pga_bw;
+} tsChannelCtrl_t;
 
 typedef struct tsScopeCalibration_s
 {
@@ -52,7 +69,7 @@ typedef struct tsScopeCalibration_s
 */
 int32_t thunderscopeCalibrationSet(tsHandle_t ts, uint32_t channel, tsChannelCalibration_t cal);
 
-
+int32_t thunderscopeCalibrationManualCtrl(tsHandle_t ts, uint32_t channel, tsChannelCtrl_t ctrl);
 #ifdef __cplusplus
 }
 #endif

--- a/include/ts_calibration.h
+++ b/include/ts_calibration.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of libtslitex.
+ * Library configuration definitions
+ *
+ * Copyright (C) 2024 / Nate Meyer  / nate.devel@gmail.com
+ *
+ */
+#ifndef _TS_CAL_H_
+#define _TS_CAL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "ts_common.h"
+
+typedef struct tsChannelCalibration_s
+{
+    int32_t buffer_mV;
+    int32_t bias_mV;
+    int32_t attenuatorGain1M_mdB;
+    int32_t attenuatorGain50_mdB;
+    int32_t bufferGain_mdB;
+    int32_t trimRheostat_range;
+    int32_t preampLowGainError_mdB;
+    int32_t preampHighGainError_mdB;
+    // int32_t preampAttenuatorGain_mdB[11]; // TBD Usage
+    int32_t preampOutputGainError_mdB;
+    int32_t preampLowOffset_mV;
+    int32_t preampHighOffset_mV;
+} tsChannelCalibration_t;
+
+
+typedef struct tsScopeCalibration_s
+{
+    tsChannelCalibration_t afeCal[TS_NUM_CHANNELS];
+
+} tsScopeCalibration_t;
+
+
+/**
+ * @brief Set the calibration data for a channel on the Thunderscope device
+ * 
+ * @param ts Handle to the Thunderscope device
+ * @param channel Channel number
+ * @param cal TBD Calibration data
+ * @return int32_t TS_STATUS_OK if the calibration was accepted
+*/
+int32_t thunderscopeCalibrationSet(tsHandle_t ts, uint32_t channel, tsChannelCalibration_t cal);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -46,10 +46,10 @@ typedef enum tsChannelTerm_e
 
 typedef struct tsDeviceInfo_s
 {
-    uint32_t deviceID;
-    char devicePath[TS_IDENT_STR_LEN];
+    uint32_t device_id;
+    char device_path[TS_IDENT_STR_LEN];
     char identity[TS_IDENT_STR_LEN];
-    char serialNumber[TS_IDENT_STR_LEN];
+    char serial_number[TS_IDENT_STR_LEN];
 } tsDeviceInfo_t;
 
 typedef struct tsChannelParam_s

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -88,12 +88,6 @@ typedef struct tsScopeState_s
 } tsScopeState_t;
 
 
-typedef struct ts_afe_cal_s
-{
-    uint32_t buffer_mv;
-    uint32_t bias_mv;
-}ts_afe_cal_t;
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/afe.h
+++ b/src/afe.h
@@ -19,6 +19,7 @@ extern "C" {
 #include "gpio.h"
 #include "lmh6518.h"
 #include "ts_common.h"
+#include "ts_calibration.h"
 
 
 typedef struct ts_afe_s
@@ -36,7 +37,7 @@ typedef struct ts_afe_s
     bool isAttenuated;
     gpio_t couplingPin;
     tsChannelCoupling_t coupling;
-    ts_afe_cal_t cal;
+    tsChannelCalibration_t cal;
 }ts_afe_t;
 
 /**

--- a/src/hmcad15xx.c
+++ b/src/hmcad15xx.c
@@ -34,6 +34,7 @@ int32_t hmcad15xx_init(hmcad15xxADC_t* adc, spi_dev_t dev)
     // Set initial configuration
     adc->mode = HMCAD15_SINGLE_CHANNEL;
     adc->width = HMCAD15_8_BIT;
+    adc->format = HMCAD15_BTC_FMT_TWOS_COMPL;
     adc->channelCfg[0].active = 1;
     adc->channelCfg[0].input = HMCAD15_ADC_IN1;
     adc->channelCfg[0].invert = 1;
@@ -240,6 +241,9 @@ static void hmcad15xxApplyLvdsMode(hmcad15xxADC_t* adc)
     // Set LVDS DDR Phase
     data = HMCAD15_LVDS_PHASE(adc->lvdsPhase);
     hmcad15xxRegWrite(adc, HMCAD15_REG_LCLK_PHASE, data);
+
+    data = HMCAD15_DATA_FMT_BTC(adc->format);
+    hmcad15xxRegWrite(adc, HMCAD15_REG_DATA_FMT, data);
 }
 
 static void hmcad15xxApplySampleMode(hmcad15xxADC_t* adc)

--- a/src/hmcad15xx.h
+++ b/src/hmcad15xx.h
@@ -108,6 +108,8 @@ extern "C" {
 
 #define HMCAD15_LVDS_PHASE(x)       (((x) & 0x03) << 5)
 
+#define HMCAD15_DATA_FMT_BTC(x)     (((x) & 0x1) << 2)
+
 #define HMCAD15_SINGLE_CH_SLP       (1 << 6)
 #define HMCAD15_DUAL_CH_1_SLP       (1 << 5)
 #define HMCAD15_DUAL_CH_0_SLP       (1 << 4)
@@ -176,6 +178,12 @@ typedef enum hmcad15xxTestMode_e
     HMCAD15_TEST_SYNC
 } hmcad15xxTestMode_t;
 
+typedef enum hmcad15xxBtcFmt_e
+{
+    HMCAD15_BTC_FMT_OFFSET,
+    HMCAD15_BTC_FMT_TWOS_COMPL
+} hmcad15xxBtcFmt_t;
+
 typedef struct hmcad15xxChCfg_s
 {
     uint8_t active;
@@ -190,6 +198,7 @@ typedef struct hmcad15xxADC_s
     spi_dev_t dev;
     hmcad15xxChCfg_t channelCfg[HMCAD15_NUM_CHANNELS];
     hmcad15xxMode_t mode;
+    hmcad15xxBtcFmt_t format;
     hmcad15xxDataWidth_t width;
     int32_t fullScale_x10;
     uint8_t clockDiv;

--- a/src/mcp443x.h
+++ b/src/mcp443x.h
@@ -21,13 +21,16 @@ extern "C" {
 
 #define MCP4432_NUM_CH  (4)
 
+#define MCP4432_RWIPER  (75)
+#define MCP4432_RANGE   (1 << 7)
+#define MCP4432_MAX     (MCP4432_RANGE-1)
 #define MCP4432_MIN     (0)
-#define MCP4432_MAX     (1 << 7)
 #define MCP4432_DEFAULT (0x40)
+#define MCP4432_FULL_SCALE_OHM  (50000)
 
-#define MCP4432_503_INC         (50000 / MCP4432_MAX)
-#define MCP4432_503_SET(x)      ((x) / MCP4432_503_INC)
-#define MCP4432_503_OHM(x)      ((x) * MCP4432_503_INC)
+#define MCP4432_503_INC         (MCP4432_FULL_SCALE_OHM / MCP4432_MAX)
+#define MCP4432_503_SET(x)      ((((x) - MCP4432_RWIPER) * MCP4432_MAX) / MCP4432_FULL_SCALE_OHM)
+#define MCP4432_503_OHM(x)      ((((x) * MCP4432_FULL_SCALE_OHM) / MCP4432_MAX) + MCP4432_RWIPER)
 
 int32_t mcp443x_set_wiper(i2c_t dev, uint8_t channel, uint8_t val);
 

--- a/src/mcp443x.h
+++ b/src/mcp443x.h
@@ -22,13 +22,11 @@ extern "C" {
 #define MCP4432_NUM_CH  (4)
 
 #define MCP4432_RWIPER  (75)
-#define MCP4432_RANGE   (1 << 7)
-#define MCP4432_MAX     (MCP4432_RANGE-1)
+#define MCP4432_MAX     (1 << 7)
 #define MCP4432_MIN     (0)
 #define MCP4432_DEFAULT (0x40)
 #define MCP4432_FULL_SCALE_OHM  (50000)
 
-#define MCP4432_503_INC         (MCP4432_FULL_SCALE_OHM / MCP4432_MAX)
 #define MCP4432_503_SET(x)      ((((x) - MCP4432_RWIPER) * MCP4432_MAX) / MCP4432_FULL_SCALE_OHM)
 #define MCP4432_503_OHM(x)      ((((x) * MCP4432_FULL_SCALE_OHM) / MCP4432_MAX) + MCP4432_RWIPER)
 

--- a/src/mcp4728.c
+++ b/src/mcp4728.c
@@ -23,7 +23,7 @@
 
 #define MCP4728_DATA_VAL_LOWER(val) ((val) & 0xFF)
 #define MCP4728_DATA_VAL_UPPER(val) (((val) >> 8) & 0x0F)
-#define MCP4728_DATA_GX(gx)         (((gx) << 4) & 0x01)
+#define MCP4728_DATA_GX(gx)         (((gx) << 4) & 0x10)
 #define MCP4728_DATA_PD(pd)         (((pd) << 5) & 0x60)
 #define MCP4728_DATA_VREF(vr)       (((vr) << 7) & 0x80)
 

--- a/src/mcp4728.h
+++ b/src/mcp4728.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include "i2c.h"
 
-#define MCP4728_FULL_SCALE_VAL      (4096)
+#define MCP4728_FULL_SCALE_VAL      (4095)
 
 typedef enum Mcp4728Vref_e
 {

--- a/src/platform.h
+++ b/src/platform.h
@@ -21,8 +21,14 @@
 #define TS_ADC_CH_INVERT        (1)
 
 #define TS_AFE_OUTPUT_NOMINAL_mVPP              (700.0)
-#define TS_ATTENUATION_VALUE_mdB                (-33979) /**< 50x Attenuation = 20 * log(1/50) * 1000 */
+#define TS_ATTENUATION_1M_GAIN_mdB              (-33979) /**< 50x Attenuation = 20 * log(1/50) * 1000 */
 #define TS_TERMINATION_50OHM_GAIN_mdB           (-13979) /**< 5x Attenuation from 50Ohm mode.  20 * log(1/5) * 1000 */
+
+#define TS_VBUFFER_NOMINAL_MV                   (2500)
+#define TS_VBIAS_NOMINAL_MV                     (2500)
+#define TS_AFE_TRIM_VDD_NOMINAL                 (5000)
+#define TS_BUFFER_GAIN_NOMINAL_mdB              (-250)
+#define TS_BIAS_RESISTOR_NOMINAL                (500)
 
 #define TS_SPI_BUS_BASE_ADDR    CSR_MAIN_SPI_BASE    
 #define TS_SPI_BUS_CS_NUM       (CSR_MAIN_SPI_CS_SEL_SIZE)

--- a/src/platform.h
+++ b/src/platform.h
@@ -29,6 +29,7 @@
 #define TS_AFE_TRIM_VDD_NOMINAL                 (5000)
 #define TS_BUFFER_GAIN_NOMINAL_mdB              (-250)
 #define TS_BIAS_RESISTOR_NOMINAL                (500)
+#define TS_PREAMP_INPUT_BIAS_CURRENT_uA         (40)
 
 #define TS_SPI_BUS_BASE_ADDR    CSR_MAIN_SPI_BASE    
 #define TS_SPI_BUS_CS_NUM       (CSR_MAIN_SPI_CS_SEL_SIZE)
@@ -49,7 +50,7 @@
 #define TS_AFE_3_TRIM_DAC       (3)
 
 #define TS_TRIM_DPOT_I2C_ADDR   (0x2C)
-#define TS_TRIM_DPOT_DEFAULT    (0x00)
+#define TS_TRIM_DPOT_DEFAULT    (0x40)
 
 #define TS_AFE_0_TRIM_DPOT      (2)
 #define TS_AFE_1_TRIM_DPOT      (0)

--- a/src/thunderscope.c
+++ b/src/thunderscope.c
@@ -13,6 +13,7 @@
 
 #include "thunderscope.h"
 #include "ts_common.h"
+#include "ts_calibration.h"
 #include "ts_channel.h"
 #include "samples.h"
 #include "util.h"
@@ -170,10 +171,16 @@ int32_t thunderscopeSampleModeSet(tsHandle_t ts, uint32_t rate, uint32_t resolut
     return TS_STATUS_ERROR;
 }
 
-int32_t thunderscopeCalibrationSet(tsHandle_t ts, uint32_t channel, uint32_t cal)
+int32_t thunderscopeCalibrationSet(tsHandle_t ts, uint32_t channel, tsChannelCalibration_t cal)
 {
-    //TODO
-    return TS_STATUS_ERROR;
+    ts_inst_t* pInst = (ts_inst_t*)ts;
+
+    if(!pInst)
+    {
+        return TS_STATUS_ERROR;
+    }
+
+    return ts_channel_calibration_set(pInst->pChannel, channel, &cal);
 }
 
 int32_t thunderscopeDataEnable(tsHandle_t ts, uint8_t enable)

--- a/src/thunderscope.c
+++ b/src/thunderscope.c
@@ -48,14 +48,14 @@ int32_t thunderscopeListDevices(uint32_t devIndex, tsDeviceInfo_t *info)
     //If index valid
     if(testDev != INVALID_HANDLE_VALUE)
     {
-        info->deviceID = devIndex;
+        info->device_id = devIndex;
         //Copy device identifier
         for (uint32_t i = 0; i < TS_IDENT_STR_LEN; i++)
         {
             info->identity[i] = (char)litepcie_readl(testDev, CSR_IDENTIFIER_MEM_BASE + 4 * i);
         }
         //TODO Implement Serial Number
-        strncpy(info->devicePath, testPath, TS_IDENT_STR_LEN);
+        strncpy(info->device_path, testPath, TS_IDENT_STR_LEN);
         litepcie_close(testDev);
         retVal = TS_STATUS_OK;
     }

--- a/src/thunderscope.c
+++ b/src/thunderscope.c
@@ -183,6 +183,18 @@ int32_t thunderscopeCalibrationSet(tsHandle_t ts, uint32_t channel, tsChannelCal
     return ts_channel_calibration_set(pInst->pChannel, channel, &cal);
 }
 
+int32_t thunderscopeCalibrationManualCtrl(tsHandle_t ts, uint32_t channel, tsChannelCtrl_t ctrl)
+{
+    ts_inst_t* pInst = (ts_inst_t*)ts;
+
+    if(!pInst)
+    {
+        return TS_STATUS_ERROR;
+    }
+
+    return ts_channel_calibration_manual(pInst->pChannel, channel, ctrl);
+}
+
 int32_t thunderscopeDataEnable(tsHandle_t ts, uint8_t enable)
 {
     int32_t status = TS_STATUS_OK;

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -492,6 +492,7 @@ int32_t ts_channel_calibration_set(tsChannelHdl_t tsChannels, uint32_t chanIdx, 
     LOG_DEBUG("\tPreamp High Input Gain Error:  %d mdB", cal->preampOutputGainError_mdB);
     LOG_DEBUG("\tPreamp Low Output Offset:      %d mV", cal->preampLowOffset_mV);
     LOG_DEBUG("\tPreamp High Output Offset:     %d mV", cal->preampHighOffset_mV);
+    LOG_DEBUG("\tPreamp Input Bias Current:     %d uA", cal->preampInputBias_uA);
 
     //Force afe to recalculate gain/offsets
     ts_channel_update_params(ts, chanIdx, &ts->chan[chanIdx].params, true);

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -146,7 +146,6 @@ int32_t ts_channel_init(tsChannelHdl_t* pTsChannels, file_t ts)
         goto channel_init_error;
     }
 
-    //TODO: Placeholder. Replace with DAC and DPot driver instances?
     i2c_t trimDac = {ts, TS_TRIM_DAC_I2C_ADDR};
     i2c_t trimPot = {ts, TS_TRIM_DPOT_I2C_ADDR};
 

--- a/src/ts_channel.h
+++ b/src/ts_channel.h
@@ -96,6 +96,16 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
  */
 int32_t ts_channel_calibration_set(tsChannelHdl_t tsChannels, uint32_t chanIdx, tsChannelCalibration_t* cal);
 
+/** 
+ * @brief Manually set the AFE controls for a channel
+ * 
+ * @param tsChannels Thunderscope Channel handle
+ * @param chanIdx Channel Index
+ * @param ctrl AFE parameters to apply
+ * @return int32_t TS_STATUS_OK on success, else TS_STATUS_ERROR
+ */
+int32_t ts_channel_calibration_manual(tsChannelHdl_t tsChannels, uint32_t chanIdx, tsChannelCtrl_t ctrl);
+
 /**
  * @brief Set the ADC into a Test Mode
  * 

--- a/src/ts_channel.h
+++ b/src/ts_channel.h
@@ -16,6 +16,7 @@ extern "C" {
 
 #include <stdint.h>
 #include "ts_common.h"
+#include "ts_calibration.h"
 #include "liblitepcie.h"
 #include "hmcad15xx.h"
 
@@ -84,6 +85,16 @@ tsScopeState_t ts_channel_scope_status(tsChannelHdl_t tsChannels);
  * @return int32_t TS_STATUS_OK on success, else TS_STATUS_ERROR
  */
 int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uint32_t resolution);
+
+/**
+ * @brief Set the calibration parameters for a channel
+ * 
+ * @param tsChannels Thunderscope Channel handle
+ * @param chanIdx Channel Index
+ * @param cal Pointer to the calibration structure to apply
+ * @return int32_t TS_STATUS_OK on success, else TS_STATUS_ERROR
+ */
+int32_t ts_channel_calibration_set(tsChannelHdl_t tsChannels, uint32_t chanIdx, tsChannelCalibration_t* cal);
 
 /**
  * @brief Set the ADC into a Test Mode


### PR DESCRIPTION
Add implementation of the calibration API to set calibration values per channel.  These calibration values are used in the AFE gain and offset calculations.

Additionally, fixes are made to the AC/DC Coupling control, opening devices of a given index, setting the ADC to 2s-Compliment mode, and adding XADC status reporting.