### PR TITLE
PLL Sample Rate Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TS_SOURCES
     src/mcp4728.c
     src/mcp443x.c
     src/mcp_clkgen.c
+    src/mcp_zl3026x.c
     src/platform.c
     src/samples.c
     src/ts_channel.c
@@ -49,6 +50,7 @@ set(TS_HEADERS
     src/adc.h
     src/afe.h
     src/mcp_clkgen.h
+    src/mcp_zl3026x.h
     src/platform.h
     src/lmh6518.h
     src/mcp4728.h

--- a/example/thunderscope_test.cpp
+++ b/example/thunderscope_test.cpp
@@ -319,20 +319,37 @@ static void test_capture(file_t fd, uint32_t idx, uint8_t channelBitmap, uint16_
         
         AudioFile<uint8_t> outWav;
         outWav.setBitDepth(8);
-        outWav.setSampleRate(1000000000/numChan);
         outWav.setNumChannels(numChan);
+        if(numChan > 2)
+        {
+            outWav.setSampleRate(1000000000/4);
+        }
+        else
+        {
+            outWav.setSampleRate(1000000000/numChan);
+        }
 
         AudioFile<uint8_t>::AudioBuffer wavBuffer;
         wavBuffer.resize(numChan);
-        wavBuffer[0].resize(sampleLen/numChan);
-        if(numChan > 1)
+        if(numChan == 1)
         {
+            wavBuffer[0].resize(sampleLen);
+        }
+        else if(numChan == 2)
+        {
+            wavBuffer[0].resize(sampleLen/numChan);
             wavBuffer[1].resize(sampleLen/numChan);
         }
-        if(numChan > 2)
+        else
         {
-            wavBuffer[2].resize(sampleLen/numChan);
-            wavBuffer[3].resize(sampleLen/numChan);
+            wavBuffer[0].resize(sampleLen/4);
+            wavBuffer[1].resize(sampleLen/4);
+            wavBuffer[2].resize(sampleLen/4);
+
+            if(numChan == 4)
+            {
+                wavBuffer[3].resize(sampleLen/4);
+            }
         }
         uint64_t sample = 0;
         uint64_t idx = 0;
@@ -345,7 +362,14 @@ static void test_capture(file_t fd, uint32_t idx, uint8_t channelBitmap, uint16_
                 if(numChan > 2)
                 {
                     wavBuffer[2][sample] = sampleBuffer[idx++];
-                    wavBuffer[3][sample] = sampleBuffer[idx++];
+                    if(numChan == 4)
+                    {
+                        wavBuffer[3][sample] = sampleBuffer[idx++];
+                    }
+                    else
+                    {
+                        idx++;
+                    }
                 }
             }
             sample++;

--- a/example/thunderscope_test.cpp
+++ b/example/thunderscope_test.cpp
@@ -42,6 +42,8 @@
 #include "../src/gpio.h"
 #include "../src/util.h"
 #include "../src/hmcad15xx.h"
+#include "../src/mcp_zl3026x.h"
+#include "../src/mcp_clkgen.h"
 
 #include "../src/ts_channel.h"
 #include "../src/samples.h"
@@ -451,6 +453,48 @@ int main(int argc, char** argv)
         exit(EXIT_FAILURE);
     }
 
+    if(0 == strcmp(arg, "clk"))
+    {
+        mcp_clkgen_conf_t test_conf[1024];
+        zl3026x_clk_config_t clk_config = {0};
+        clk_config.in_clks[1].enable = 1;
+        clk_config.in_clks[1].input_freq = 10000000;
+        clk_config.input_select = ZL3026X_INPUT_IC2;
+        clk_config.out_clks[0].enable = 1;
+        clk_config.out_clks[0].output_freq = 10000000;
+        clk_config.out_clks[0].output_mode = ZL3026X_OUT_CMOS_P;
+        clk_config.out_clks[0].output_pll_select = ZL3026X_PLL_BYPASS;
+        clk_config.out_clks[5].enable = 1;
+        clk_config.out_clks[5].output_freq = 1000000000;
+        clk_config.out_clks[5].output_mode = ZL3026X_OUT_DIFF;
+        clk_config.out_clks[5].output_pll_select = ZL3026X_PLL_INT_DIV;
+
+        int32_t clk_result = mcp_zl3026x_build_config(test_conf, 1024, clk_config);
+
+        if(clk_result < 1)
+        {
+            printf("Invalid Clock Configuration: %d\n", clk_result);
+            return -1;
+        }
+        else
+        {
+            printf("MCP Clock Configuration Array (Len %d)\n", clk_result);
+            uint16_t idx = 0;
+            while(idx < clk_result)
+            {
+                if(test_conf[idx].action == MCP_CLKGEN_WRITE_REG)
+                {
+                    printf("\t{WRITE_REG: 0x%04X  0x%02X}\n", test_conf[idx].addr, test_conf[idx].value);
+                }
+                else
+                {
+                    printf("\t{DELAY: %d us}\n", test_conf[idx].delay_us);
+                }
+                idx++;
+            }
+        }
+        return 0;
+    }
 
     snprintf(devicePath, TS_IDENT_STR_LEN, LITEPCIE_CTRL_NAME(%d), idx);
     printf("Opening Device %s\n", devicePath);

--- a/include/thunderscope.h
+++ b/include/thunderscope.h
@@ -78,7 +78,8 @@ int32_t thunderscopeStatusGet(tsHandle_t ts, tsScopeState_t* conf);
  * @brief Set the sample rate and format for the Thunderscope device
  * 
  * @param ts Handle to the Thunderscope device
- * @param rate Sample Rate to collect
+ * @param rate Sample Rate to collect (samples per second)
+ * @param resolution Resolution to sample at. 256 or 4096
  * @return int32_t TS_STATUS_OK if the Thunderscope was configured
 */
 int32_t thunderscopeSampleModeSet(tsHandle_t ts, uint32_t rate, uint32_t resolution);

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -25,6 +25,8 @@ extern "C" {
 
 #define TS_IDENT_STR_LEN            (256)
 
+#define TS_MIN_SAMPLE_RATE          (270000000)
+
 /**
  * @brief Opaque Handle to a Thunderscope device instance
  *  

--- a/include/ts_common.h
+++ b/include/ts_common.h
@@ -25,7 +25,8 @@ extern "C" {
 
 #define TS_IDENT_STR_LEN            (256)
 
-#define TS_MIN_SAMPLE_RATE          (270000000)
+#define TS_MAX_SAMPLE_RATE          (1000000000)
+#define TS_MIN_SAMPLE_RATE          (15000000)
 
 /**
  * @brief Opaque Handle to a Thunderscope device instance

--- a/src/adc.c
+++ b/src/adc.c
@@ -109,6 +109,7 @@ int32_t ts_adc_channel_enable(ts_adc_t* adc, uint8_t channel, uint8_t enable)
 {
     int32_t retVal;
     uint8_t activeCount = 0;
+    uint8_t inactiveCount = 0;
     adc_shuffle_t shuffleMode = ADC_SHUFFLE_1CH;
 
     adc->tsChannels[channel].active = enable;
@@ -122,14 +123,14 @@ int32_t ts_adc_channel_enable(ts_adc_t* adc, uint8_t channel, uint8_t enable)
             adc->adcDev.channelCfg[activeCount] = adc->tsChannels[i];
             activeCount++;
         }
-    }
-
-    //Disable Unused channels in config
-    for(uint8_t i=activeCount; i < HMCAD15_NUM_CHANNELS; i++)
-    {
-        LOG_DEBUG("Disable CH %d", i);
-
-        adc->adcDev.channelCfg[i].active = 0;
+        else
+        {
+            //Disable Unused channels in config
+            LOG_DEBUG("Disable CH %d", i);
+            adc->adcDev.channelCfg[TS_NUM_CHANNELS - inactiveCount] = adc->tsChannels[i];
+            adc->adcDev.channelCfg[TS_NUM_CHANNELS - inactiveCount].active = 0;
+            inactiveCount++;
+        }
     }
 
     if(activeCount == 0)

--- a/src/adc.c
+++ b/src/adc.c
@@ -193,3 +193,19 @@ int32_t ts_adc_run(ts_adc_t* adc, uint8_t en)
     litepcie_writel(adc->ctrl, CSR_ADC_TRIGGER_CONTROL_ADDR, en);
     return TS_STATUS_OK;
 }
+
+int32_t ts_adc_set_sample_mode(ts_adc_t* adc, uint32_t sample_rate, uint32_t resolution)
+{
+    if(!adc)
+    {
+        return TS_STATUS_ERROR;
+    }
+    hmcad15xxDataWidth_t data_mode = HMCAD15_8_BIT;
+    if(resolution == 4096)
+    {
+        data_mode = HMCAD15_12_BIT;
+    }
+    //else support 14-bit precise mode?
+
+    return hmcad15xx_set_sample_mode(&adc->adcDev, sample_rate , data_mode);
+}

--- a/src/adc.h
+++ b/src/adc.h
@@ -85,6 +85,16 @@ int32_t ts_adc_shutdown(ts_adc_t* adc);
  */
 int32_t ts_adc_run(ts_adc_t* adc, uint8_t en);
 
+/**
+ * @brief Set the expected Sample Rate and Resolution for the ADC
+ * 
+ * @param adc Pointer to a ADC instance
+ * @param sample_rate Rate of the ADC Sample clock (Hz)
+ * @param resolution Resolution mode setting for the ADC.
+ * @return int32_t TS_STATUS_OK if the mode was applied successfully
+ */
+int32_t ts_adc_set_sample_mode(ts_adc_t* adc, uint32_t sample_rate, uint32_t resolution);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hmcad15xx.h
+++ b/src/hmcad15xx.h
@@ -105,6 +105,7 @@ extern "C" {
 #define HMCAD15_LVDS_DS_DATA(x)     (((x) & 0x07) << 8)
 
 #define HMCAD15_DATA_WIDTH(x)       ((x) & 0x07)
+#define HMCAD15_LOW_CLK(x)          (((x) & 0x01) << 3)
 
 #define HMCAD15_LVDS_PHASE(x)       (((x) & 0x03) << 5)
 
@@ -145,6 +146,9 @@ extern "C" {
 
 #define HMCAD15_CLK_DIV_DEFAULT     (1)
 #define HMCAD15_LVDS_PHASE_DEFAULT  (HMCAD15_LVDS_PHASE_0DEG)
+
+#define HMCAD15_HS_LOW_CLK_THRESHOLD    (120000000)
+#define HMCAD15_PREC_LOW_CLK_THRESHOLD  (30000000)
 
 typedef enum hmcad15xxMode_e
 {
@@ -204,6 +208,7 @@ typedef struct hmcad15xxADC_s
     uint8_t clockDiv;
     uint8_t lvdsPhase;
     uint8_t drive;
+    uint8_t low_clk;
 } hmcad15xxADC_t;
 
 /**
@@ -263,6 +268,16 @@ int32_t hmcad15xx_full_scale_adjust(hmcad15xxADC_t* adc, int8_t adjustment);
  * @return int32_t TS_STATUS_OK if successful
  */
 int32_t hmcad15xx_set_test_pattern(hmcad15xxADC_t* adc, hmcad15xxTestMode_t mode, uint16_t testData1, uint16_t testData2);
+
+/**
+ * @brief Update the HMCAD15xx data interface
+ * 
+ * @param adc Pointer to an ADC Instance
+ * @param sample_rate Sample Clock Rate (Hz)
+ * @param width ADC Sample Width
+ * @return int32_t TS_STATUS_OK if successful
+ */
+int32_t hmcad15xx_set_sample_mode(hmcad15xxADC_t* adc, uint32_t sample_rate, hmcad15xxDataWidth_t width);
 
 #ifdef __cplusplus
 }

--- a/src/mcp_clkgen.h
+++ b/src/mcp_clkgen.h
@@ -15,6 +15,8 @@ extern "C" {
 
 #include "i2c.h"
 
+#define MCP_CLKGEN_ARR_MAX_LEN  (100)
+
 typedef enum mcp_clkgen_action_e {
     MCP_CLKGEN_DELAY,
     MCP_CLKGEN_WRITE_REG

--- a/src/mcp_zl3026x.c
+++ b/src/mcp_zl3026x.c
@@ -174,6 +174,12 @@ int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl30
         }
     }
 
+    //Scale pll_out to be in a good range
+    while(pll_out < ZL3026X_MIN_PLL_OUT)
+    {
+        pll_out *= 2;
+    }
+
     uint64_t pll_vco = 4200000000;
     uint32_t pll_int_div = pll_vco/pll_out;
     //validate pll_int_div 4-15

--- a/src/mcp_zl3026x.c
+++ b/src/mcp_zl3026x.c
@@ -1,0 +1,423 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of libtslitex.
+ * Driver for the zl30260 Clock Generator as used
+ * in the Thunderscope.  Datasheet reference at 
+ * https://ww1.microchip.com/downloads/aemDocuments/documents/TCG/ProductDocuments/DataSheets/ZL30260-1-2-3-1-APLL-6-or-10-Output-Any-to-Any-Clock-Multiplier-and-Frequency-Synthesizer-DS20006554.pdf
+ *
+ * Copyright (C) 2024 / Nate Meyer  / nate.devel@gmail.com
+ *
+ */
+
+#include "mcp_zl3026x.h"
+#include "mcp_clkgen.h"
+
+#include "util.h"
+
+
+#define MCP_ADD_REG_WRITE(conf, reg, val)   { (conf)->action = MCP_CLKGEN_WRITE_REG; \
+                                              (conf)->addr = (reg); \
+                                              (conf)->value = (val); }
+
+#define MCP_ADD_DELAY(conf, delay)          { (conf)->action = MCP_CLKGEN_DELAY; \
+                                              (conf)->delay_us = (delay); }
+
+static const uint8_t g_outClkGroups[ZL3026X_NUM_OUTPUT_CLK] = {0, 0, 1, 2, 2, 3, 3, 4, 5, 5};
+
+static uint64_t mcp_zl3026x_selected_input_freq(zl3026x_clk_config_t *conf);
+
+int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl3026x_clk_config_t conf)
+{
+    int32_t calLen = 0;
+
+    // Reference App Note ZLAN-590
+    // https://ww1.microchip.com/downloads/aemDocuments/documents/TCG/ApplicationNotes/ApplicationNotes/ConfigurationSequenceZLAN-590.pdf
+
+    //ZL3026x Init
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0423, 0x08);
+    calLen++;
+
+    // Enable Outputs by setting OCEN1 and OCEN2
+    uint16_t out_ch_bitmap = 0;
+    for(uint8_t ch = 0; ch < ZL3026X_NUM_OUTPUT_CLK; ch++)
+    {
+        if(conf.out_clks[ch].enable)
+        {
+            out_ch_bitmap |= (1UL << ch);
+        }
+    }
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0005, (out_ch_bitmap & 0xff));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0006, ((out_ch_bitmap >> 8) & 0xFF));
+    calLen++;
+
+    // Stop Outputs
+    for(uint8_t ch = 0; ch < ZL3026X_NUM_OUTPUT_CLK; ch++)
+    {
+        if(conf.out_clks[ch].enable)
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], (0x20A + (0x10*ch)), 0x0C);
+            calLen++;
+        }
+    }
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0009, (out_ch_bitmap & 0xff));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x000A, ((out_ch_bitmap >> 8) & 0xFF));
+    calLen++;
+
+    // Configure Input Clock Source:
+    // Enable/Disable XA/XB Inputs
+    if(conf.in_xo.enable)
+    {
+        // TODO
+    }
+    // Enable/Disable Input Clocks
+    else
+    {
+        uint8_t in_ch_bitmap = 0;
+        for(uint8_t ch = 0; ch < ZL3026X_NUM_INPUT_CLK; ch++)
+        {
+            if(conf.in_clks[ch].enable)
+            {
+                MCP_ADD_REG_WRITE(&confData[calLen], (0x0303+ch), (uint8_t)conf.in_clks[ch].input_divider);
+                calLen++;
+                in_ch_bitmap |= (1 << ch);
+                break;
+            }
+        }
+        if(in_ch_bitmap == 0)
+        {
+            //ERROR
+            LOG_ERROR("Invalid Clock Config: No Input Clocks Enabled");
+            return -1;
+        }
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0004, in_ch_bitmap);
+        calLen++;
+    }
+
+
+    // Select Source for Output Multiplexers
+    uint8_t clkMuxABC = 0, clkMuxDEF = 0;
+    for(uint8_t chA = 0; chA < ZL3026X_NUM_OUTPUT_CLK; chA++)
+    {
+        if(conf.out_clks[chA].enable)
+        {
+            for(uint8_t chB=0; chB < ZL3026X_NUM_OUTPUT_CLK; chB++)
+            {
+                if((chA != chB) && (conf.out_clks[chB].enable)
+                    && (g_outClkGroups[chA] == g_outClkGroups[chB])
+                    && (conf.out_clks[chA].output_pll_select != conf.out_clks[chB].output_pll_select))
+                {
+                    //Error
+                    LOG_ERROR("Clock Configuration error: Out %d and %d are in the same group but have different PLL Configs", chA, chB);
+                    return -1;
+                }
+            }
+            uint8_t pll_mux = 0; // ZL3026X_PLL_INT_DIV
+            if (conf.out_clks[chA].output_pll_select == ZL3026X_PLL_FRAC_DIV ||
+                conf.out_clks[chA].output_pll_select == ZL3026X_PLL_BYPASS)
+            {
+                pll_mux = 1;
+            }
+            else if( conf.out_clks[chA].output_pll_select == ZL3026X_PLL_BYPASS_2)
+            {
+                pll_mux = 3;
+            }
+
+            if(g_outClkGroups[chA] < 3)
+            {
+                clkMuxABC |= (pll_mux << (2*g_outClkGroups[chA]));
+            }
+            else
+            {
+                clkMuxDEF |= (pll_mux << (2*g_outClkGroups[chA]));
+            }
+        }
+    }
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0007, clkMuxABC);
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0008, clkMuxDEF);
+    calLen++;
+
+    // Configure GPIO Pins
+    //TODO
+
+    // Determine PLL Configuration
+    /** 
+     * Find a common ratio for the selected output frequencies
+     */
+    uint64_t pll_out = 1;
+    uint64_t clk_max = 1;
+    uint8_t pll_frac_bypass = 0;
+    for(uint8_t ch = 0; ch < ZL3026X_NUM_OUTPUT_CLK; ch++)
+    {
+        if(conf.out_clks[ch].enable)
+        {
+            if (conf.out_clks[ch].output_pll_select == ZL3026X_PLL_INT_DIV)
+            {
+                //Find the least-common multiple
+                uint64_t freq_mult = pll_out;
+                uint64_t freq_mod = conf.out_clks[ch].output_freq;
+                while(freq_mod != 0)
+                {
+                    uint64_t freq_temp = freq_mult;
+                    freq_mult = freq_mod;
+                    freq_mod = freq_temp % freq_mod;
+                }
+                pll_out = (pll_out * conf.out_clks[ch].output_freq) / freq_mult;
+            }
+            else if (conf.out_clks[ch].output_pll_select == ZL3026X_PLL_BYPASS)
+            {
+                pll_frac_bypass = 1;
+            }
+        }
+    }
+
+    uint64_t pll_vco = 4200000000;
+    uint32_t pll_int_div = pll_vco/pll_out;
+    //validate pll_int_div 4-15
+    if(pll_int_div < 4 || pll_int_div > 15)
+    {
+        LOG_ERROR("Invalid APLL Configuration: Int Div %u", pll_int_div);
+        return -1;
+    }
+
+    //Get exact VCO frequency
+    pll_vco = pll_out * pll_int_div;
+    //validate VCO between 3.7GHz and 4.2GHz
+    if(pll_vco < 3700000000 || pll_vco > 4200000000)
+    {
+        LOG_ERROR("Invalid APLL Configuration: VCO Freq %llu", pll_vco);
+        return -1;
+    }
+
+    double multiplier = pll_vco / mcp_zl3026x_selected_input_freq(&conf);
+    int64_t pll_numerator = 0;
+    int64_t pll_denominator = 1;
+    //TODO - Determine N & D parameters
+
+    // Configure APLL1
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0003, 0x01); //Enable PLL
+    calLen++;
+
+    //TODO Enable useage of the fractional divider
+    uint8_t pll_conf_1 = (0x2 * pll_frac_bypass);
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0100, 0x40 | pll_conf_1); //Enable PLL
+    calLen++;
+
+    if(pll_int_div < 8)
+    {
+        pll_int_div = (pll_int_div - 4)*2;
+    }
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0101, pll_int_div & 0x0F); //PLL Output Integer Divide
+    calLen++;
+
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0102, (conf.input_select & 0x7)); //PLL Input
+    calLen++;
+
+    //PLL AFBDIV
+    /* The PLL configures the multiplier using a fixed-precision value,
+     * consisting of 9 integer bits and 33 fractional bits.
+     * Split the float value into the whole number and decimal number.
+     */
+    uint16_t mult_int = (uint16_t)multiplier;
+    uint64_t mult_frac = (uint64_t)((multiplier - (double)mult_int) * pow(2,33));
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0106, (mult_frac & 0xFF));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0107, ((mult_frac >> 8) & 0xFF));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0108, ((mult_frac >> 16) & 0xFF));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0109, ((mult_frac >> 24) & 0xFF));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x010A, (((mult_int << 1) & 0xFE) | ((mult_frac >> 32) & 0x01)));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x010B, ((mult_int >> 7) & 0x03));
+    calLen++;
+
+    //TODO: PLL AFBDEN
+    //TODO: PLL AFBREM
+
+    // Configure APLL1 Analog
+    //Assume no spread-spectrum
+    if(mult_frac == 0)
+    {
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0120, 0xC7);
+        calLen++;
+        if(mcp_zl3026x_selected_input_freq(&conf) < 50000000)
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0121, 0x60);
+        }
+        else
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0121, 0x40);
+        }
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0122, 0x7F);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0123, 0x00);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0124, 0x04);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0125, 0xB3);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0126, 0xD8);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0127, 0x90);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x423, 0x08);
+        calLen++;
+    }
+    else if(mult_frac == 0x100000000)
+    {
+        if(mcp_zl3026x_selected_input_freq(&conf) < 50000000)
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0120, 0xC7);
+        }
+        else
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0120, 0xC3);
+        }
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0121, 0x40);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0122, 0x7F);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0123, 0x00);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0124, 0x04);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0125, 0xB3);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0126, 0xD8);
+        calLen++;
+        
+        if(mcp_zl3026x_selected_input_freq(&conf) < 50000000)
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0127, 0x50);
+        }
+        else
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0127, 0x90);
+        }
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0423, 0x08);
+        calLen++;
+    }
+    else
+    {
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0120, 0xC7);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0121, 0x40);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0122, 0x5F);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0123, 0x00);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0124, 0x04);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0125, 0xB3);
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0126, 0x98);
+        calLen++;
+        
+        if(mcp_zl3026x_selected_input_freq(&conf) < 80000000)
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0127, 0x50);
+        }
+        else
+        {
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0127, 0x90);
+        }
+        calLen++;
+        MCP_ADD_REG_WRITE(&confData[calLen], 0x0423, 0x1B);
+        calLen++;
+    }
+
+    // Configure APLL1 Fractional Output Divider
+    //TODO
+
+    // Configure APLL1 Fractional Output Divider Analog
+    //TODO
+
+    // Configure Output Divider Registers
+    for(uint8_t ch = 0; ch < ZL3026X_NUM_OUTPUT_CLK; ch++)
+    {
+        if(conf.out_clks[ch].enable)
+        {
+            uint8_t out_div = 0;
+            out_div = 0x80; //Phase align output
+
+            if(conf.out_clks[ch].output_pll_select == ZL3026X_PLL_INT_DIV)
+            {
+                if(conf.out_clks[ch].output_freq != pll_out)
+                {
+                   out_div |= (pll_out/conf.out_clks[ch].output_freq) & 0x7F;
+                }
+            }
+            //TODO Support Low-speed divider
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0200+(ch*0x10), out_div);
+            calLen++;
+            
+            MCP_ADD_REG_WRITE(&confData[calLen], 0x0201+(ch*0x10), conf.out_clks[ch].output_mode);
+            calLen++;
+        }
+    }
+
+    // APLL1 Relock Sequence
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0430, 0x0C);
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0430, 0x00);
+    calLen++;
+
+    // Delay 2ms
+    MCP_ADD_DELAY(&confData[calLen], 2000);
+    calLen++;
+
+    // Align APLL Outputs
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0100, pll_conf_1 & ~(0x40));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0100, 0x40 | pll_conf_1);
+    calLen++;
+    
+    // Disable Ring Oscillator
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0001, 0x28);
+    calLen++;
+
+    //Set Interrupt Bits
+    // N/A
+
+    // Start Outputs
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0001, 0x08);
+    calLen++;
+   
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x0009, (~out_ch_bitmap & 0xff));
+    calLen++;
+    MCP_ADD_REG_WRITE(&confData[calLen], 0x000A, ((~out_ch_bitmap >> 8) & 0xFF));
+    calLen++;
+
+    // Delay 2ms
+    MCP_ADD_DELAY(&confData[calLen], 2000);
+    calLen++;
+
+    return calLen;
+}
+
+static uint64_t mcp_zl3026x_selected_input_freq(zl3026x_clk_config_t *conf)
+{
+    uint64_t freq = 0;
+    switch(conf->input_select) {
+    case ZL3026X_INPUT_IC1:
+    case ZL3026X_INPUT_IC2:
+    case ZL3026X_INPUT_IC3:
+        freq = conf->in_clks[conf->input_select].input_freq / (1 << conf->in_clks[conf->input_select].input_divider);
+        break;
+    case ZL3026X_INPUT_XO:
+        freq = conf->in_xo.xo_freq;
+        break;
+    case ZL3026X_INPUT_XO_DBL:
+        freq = conf->in_xo.xo_freq*2;
+        break;
+    }
+    return freq;
+}

--- a/src/mcp_zl3026x.c
+++ b/src/mcp_zl3026x.c
@@ -13,6 +13,7 @@
 #include "mcp_clkgen.h"
 
 #include "util.h"
+#include "ts_common.h"
 
 
 #define MCP_ADD_REG_WRITE(conf, reg, val)   { (conf)->action = MCP_CLKGEN_WRITE_REG; \
@@ -89,7 +90,7 @@ int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl30
         {
             //ERROR
             LOG_ERROR("Invalid Clock Config: No Input Clocks Enabled");
-            return -1;
+            return TS_STATUS_ERROR;
         }
         MCP_ADD_REG_WRITE(&confData[calLen], 0x0004, in_ch_bitmap);
         calLen++;
@@ -110,7 +111,7 @@ int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl30
                 {
                     //Error
                     LOG_ERROR("Clock Configuration error: Out %d and %d are in the same group but have different PLL Configs", chA, chB);
-                    return -1;
+                    return TS_STATUS_ERROR;
                 }
             }
             uint8_t pll_mux = 0; // ZL3026X_PLL_INT_DIV
@@ -179,7 +180,7 @@ int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl30
     if(pll_int_div < 4 || pll_int_div > 15)
     {
         LOG_ERROR("Invalid APLL Configuration: Int Div %u", pll_int_div);
-        return -1;
+        return TS_INVALID_PARAM;
     }
 
     //Get exact VCO frequency
@@ -188,7 +189,7 @@ int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl30
     if(pll_vco < 3700000000 || pll_vco > 4200000000)
     {
         LOG_ERROR("Invalid APLL Configuration: VCO Freq %llu", pll_vco);
-        return -1;
+        return TS_INVALID_PARAM;
     }
 
     double multiplier = pll_vco / mcp_zl3026x_selected_input_freq(&conf);

--- a/src/mcp_zl3026x.h
+++ b/src/mcp_zl3026x.h
@@ -22,6 +22,9 @@ extern "C" {
 #define ZL3026X_NUM_INPUT_CLK   (3)
 #define ZL3026X_NUM_OUTPUT_CLK  (10)
 
+#define ZL3026X_MIN_PLL_OUT     (267000000)
+#define ZL3026X_MAX_PLL_OUT     (1050000000)
+
 typedef enum zl3026x_input_e {
     ZL3026X_INPUT_IC1,
     ZL3026X_INPUT_IC2,

--- a/src/mcp_zl3026x.h
+++ b/src/mcp_zl3026x.h
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of libtslitex.
+ * Driver for the zl30260 Clock Generator as used
+ * in the Thunderscope.  Datasheet reference at 
+ * https://ww1.microchip.com/downloads/aemDocuments/documents/TCG/ProductDocuments/DataSheets/ZL30260-1-2-3-1-APLL-6-or-10-Output-Any-to-Any-Clock-Multiplier-and-Frequency-Synthesizer-DS20006554.pdf
+ *
+ * Copyright (C) 2024 / Nate Meyer  / nate.devel@gmail.com
+ *
+ */
+#ifndef _MCP_ZL3026X_H_
+#define _MCP_ZL3026X_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mcp_clkgen.h"
+
+//TODO: Register Map
+
+#define ZL3026X_NUM_INPUT_CLK   (3)
+#define ZL3026X_NUM_OUTPUT_CLK  (10)
+
+typedef enum zl3026x_input_e {
+    ZL3026X_INPUT_IC1,
+    ZL3026X_INPUT_IC2,
+    ZL3026X_INPUT_IC3,
+    ZL3026X_INPUT_XO,
+    ZL3026X_INPUT_XO_DBL
+} zl3026x_input_t;
+
+typedef enum zl3026x_input_div_e {
+    ZL3026X_IN_DIV_1 = 0,
+    ZL3026X_IN_DIV_2 = 1,
+    ZL3026X_IN_DIV_4 = 2,
+    ZL3026X_IN_DIV_8 = 3
+} zl3026x_input_div_t;
+
+typedef enum zl3026x_clk_src_e {
+    ZL3026X_PLL_INT_DIV,
+    ZL3026X_PLL_FRAC_DIV,
+    ZL3026X_PLL_BYPASS,
+    ZL3026X_PLL_BYPASS_2,
+} zl3026x_clk_src_t;
+
+typedef enum zl3026x_out_mode_e {
+    ZL3026X_OUT_DISABLED = 0,
+    ZL3026X_OUT_LVDS = 1,
+    ZL3026X_OUT_DIFF = 2,
+    ZL3026X_OUT_HSTL = 3,
+    ZL3026X_OUT_CMOS_2 = 4,
+    ZL3026X_OUT_CMOS_P = 5,
+    ZL3026X_OUT_CMOS_N = 6,
+    ZL3026X_OUT_CMOS_OPP = 7,
+    ZL3026X_OUT_HCSL = 10,
+} zl3026x_out_mode_t;
+
+typedef struct zl3026x_input_xo_s {
+    uint8_t enable;
+    uint64_t xo_freq;
+    //TODO Add Crystal Oscillator Config
+} zl3026x_input_xo_t;
+
+typedef struct zl3026x_input_clk_s {
+    uint8_t enable;
+    uint64_t input_freq;
+    zl3026x_input_div_t input_divider;
+} zl3026x_input_clk_t;
+
+typedef struct zl3026x_output_clk_s {
+    uint8_t enable;
+    uint64_t output_freq;
+    zl3026x_out_mode_t output_mode;
+    zl3026x_clk_src_t output_pll_select;
+} zl3026x_output_clk_t;
+
+typedef struct zl3026x_clk_config_s {
+    zl3026x_input_xo_t in_xo;
+    zl3026x_input_clk_t in_clks[ZL3026X_NUM_INPUT_CLK];
+    zl3026x_output_clk_t out_clks[ZL3026X_NUM_OUTPUT_CLK];
+    zl3026x_input_t input_select;
+    //TODO Add GPIO Config
+} zl3026x_clk_config_t;
+
+int32_t mcp_zl3026x_build_config(mcp_clkgen_conf_t* confData, uint32_t len, zl3026x_clk_config_t conf);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/platform.h
+++ b/src/platform.h
@@ -10,6 +10,7 @@
 
 #include "ts_common.h"
 #include "mcp_clkgen.h"
+#include "mcp_zl3026x.h"
 #include "csr.h"
 
 
@@ -74,6 +75,22 @@ extern const uint32_t ZL30260_CONF_SIZE;
 #define TS_PLL_I2C_ADDR         ZL30260_I2C_ADDR
 #define TS_PLL_CONF             ZL30260_CONF
 #define TS_PLL_CONF_SIZE        ZL30260_CONF_SIZE
+#define TS_PLL_INPUT_IDX        (1)
+#define TS_PLL_INPUT_RATE       (10000000)
+#define TS_PLL_INPUT_SEL        (ZL3026X_INPUT_IC2)
+
+#define TS_PLL_REFIN_IDX        (0)
+#define TS_PLL_REFIN_SEL        (ZL3026X_INPUT_IC1)
+
+#define TS_PLL_REFOUT_CLK_IDX       (0)
+#define TS_PLL_REFOUT_RATE_DEFAULT  (10000000)
+#define TS_PLL_REFOUT_CLK_MODE      (ZL3026X_OUT_CMOS_P)
+#define TS_PLL_REFOUT_PLL_MODE      (ZL3026X_PLL_BYPASS)
+
+#define TS_PLL_SAMPLE_CLK_IDX       (5)
+#define TS_PLL_SAMPLE_RATE_DEFAULT  (1000000000)
+#define TS_PLL_SAMPLE_CLK_MODE      (ZL3026X_OUT_DIFF)
+#define TS_PLL_SAMPLE_PLL_MODE      (ZL3026X_PLL_INT_DIV)
 #endif
 
 #define TS_PLL_NRST_ADDR        CSR_ADC_CONTROL_ADDR

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -489,7 +489,7 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
     }
     //Input validation
     //TODO - Support valid rate/resolution combinations
-    if((rate < 270000000) || (resolution != 256))
+    if((rate < TS_MIN_SAMPLE_RATE) || (resolution != 256))
     {
         return TS_INVALID_PARAM;
     }
@@ -503,13 +503,16 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
     int32_t clk_len = mcp_zl3026x_build_config(clk_regs, MCP_CLKGEN_ARR_MAX_LEN, newConf);
     if(clk_len > 0)
     {
-        mcp_clkgen_config(ts->pll.clkGen, clk_regs, clk_len);
+        if(TS_STATUS_OK != mcp_clkgen_config(ts->pll.clkGen, clk_regs, clk_len))
+        {
+            return TS_STATUS_ERROR;
+        }
         ts->pll.clkConf = newConf;
     }
     else
     {
         LOG_ERROR("Failed to generate PLL Configuration: %d", clk_len);
-        return TS_STATUS_ERROR;
+        return clk_len;
     }
 
     ts->status.adc_sample_rate = rate;

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -424,7 +424,8 @@ static int32_t ts_channel_update_params(ts_channel_t* pTsHdl, uint32_t chanIdx, 
         else
         {
             LOG_DEBUG("Channel %d AFE set to %i mV offset", chanIdx, offset_actual);
-            pTsHdl->chan[chanIdx].params.volt_offset_mV = offset_actual;
+            // pTsHdl->chan[chanIdx].params.volt_offset_mV = offset_actual;
+            pTsHdl->chan[chanIdx].params.volt_offset_mV = param->volt_offset_mV;
         }
     }
 

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -489,7 +489,8 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
     }
     //Input validation
     //TODO - Support valid rate/resolution combinations
-    if((rate < TS_MIN_SAMPLE_RATE) || (resolution != 256))
+    if((rate < TS_MIN_SAMPLE_RATE) || (rate > TS_MAX_SAMPLE_RATE)
+         || (resolution != 256))
     {
         return TS_INVALID_PARAM;
     }

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -520,6 +520,8 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
     ts->status.adc_sample_resolution = resolution;
     ts->status.adc_sample_bits = resolution == 256 ? 8 : 16;
 
+    ts_adc_set_sample_mode(&ts->adc, rate, resolution);
+
     return  TS_STATUS_OK;
 }
 


### PR DESCRIPTION
Add ability to change sample rates.

Added driver to generate ZL3026X register map for arbitrary clock configuration.

Fix channel offset voltage drifting when changing channel gain.

Fix ADC channel configuration when 3 channels are active.