### PR TITLE
Improve PLL Calculations

### DIFF
--- a/example/thunderscope_test.cpp
+++ b/example/thunderscope_test.cpp
@@ -503,7 +503,7 @@ int main(int argc, char** argv)
         else
         {
             printf("MCP Clock Configuration Array (Len %d)\n", clk_result);
-            uint16_t idx = 0;
+            int32_t idx = 0;
             while(idx < clk_result)
             {
                 if(test_conf[idx].action == MCP_CLKGEN_WRITE_REG)

--- a/src/adc.c
+++ b/src/adc.c
@@ -207,5 +207,15 @@ int32_t ts_adc_set_sample_mode(ts_adc_t* adc, uint32_t sample_rate, uint32_t res
     }
     //else support 14-bit precise mode?
 
-    return hmcad15xx_set_sample_mode(&adc->adcDev, sample_rate , data_mode);
+    if(TS_STATUS_OK == hmcad15xx_set_sample_mode(&adc->adcDev, sample_rate, data_mode))
+    {
+        hmcad15xx_set_channel_config(&adc->adcDev);
+        litepcie_writel(adc->ctrl, CSR_ADC_HAD1511_CONTROL_ADDR, 1 << CSR_ADC_HAD1511_CONTROL_FRAME_RST_OFFSET);
+        return TS_STATUS_OK;
+    }
+    else
+    {
+        LOG_ERROR("Failed to set the ADC Sample Mode %d/%d", sample_rate, resolution);
+        return TS_STATUS_ERROR;
+    }
 }

--- a/src/mcp_zl3026x.h
+++ b/src/mcp_zl3026x.h
@@ -25,6 +25,8 @@ extern "C" {
 #define ZL3026X_MIN_PLL_OUT     (267000000)
 #define ZL3026X_MAX_PLL_OUT     (1050000000)
 
+#define ZL3026X_OUT_MDIV_MIN_CLK    (375000000)
+
 typedef enum zl3026x_input_e {
     ZL3026X_INPUT_IC1,
     ZL3026X_INPUT_IC2,

--- a/src/ts_channel.c
+++ b/src/ts_channel.c
@@ -430,6 +430,8 @@ static int32_t ts_channel_update_params(ts_channel_t* pTsHdl, uint32_t chanIdx, 
     //Set Active
     if(param->active != pTsHdl->chan[chanIdx].params.active)
     {
+        //ADC Run will be reenabled when updating the sample rate
+        ts_adc_run(&pTsHdl->adc, 0);
         retVal = ts_adc_channel_enable(&pTsHdl->adc, chanIdx, param->active);
 
         if(TS_STATUS_OK != retVal)
@@ -524,6 +526,8 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
 
     if(actual_rate != ts->pll.clkConf.out_clks[TS_PLL_SAMPLE_CLK_IDX].output_freq)
     {
+        ts_adc_run(&ts->adc, 0);
+        
         // Apply resolution,rate configuration
         zl3026x_clk_config_t newConf = ts->pll.clkConf;
         newConf.out_clks[TS_PLL_SAMPLE_CLK_IDX].output_freq = actual_rate;
@@ -549,6 +553,7 @@ int32_t ts_channel_sample_rate_set(tsChannelHdl_t tsChannels, uint32_t rate, uin
         ts->status.adc_sample_bits = resolution == 256 ? 8 : 16;
 
         ts_adc_set_sample_mode(&ts->adc, rate, resolution);
+        ts_adc_run(&ts->adc, ts->status.adc_state);
     }
 
     return  TS_STATUS_OK;


### PR DESCRIPTION
Improve PLL Calculations to properly set the output medium-speed and low-speed dividers.  Add code to stop and start the ADC stream when making changes to the clock.